### PR TITLE
improve import handling / module finding

### DIFF
--- a/langserver/definitions.py
+++ b/langserver/definitions.py
@@ -49,6 +49,34 @@ class TargetedSymbolVisitor:
                     container=container
                 )
                 break
+            if n.asname and self.name == n.asname:
+                yield Symbol(
+                    n.asname,
+                    SymbolKind.Variable,
+                    node.lineno,
+                    node.col_offset,
+                    container=container
+                )
+                break
+
+    def visit_Import(self, node, container):
+        for n in node.names:
+            if n.name and self.name in n.name.split("."):
+                yield Symbol(
+                    n.name,
+                    SymbolKind.Variable,
+                    node.lineno,
+                    node.col_offset,
+                    container=container
+                )
+            if n.asname and self.name == n.asname:
+                yield Symbol(
+                    n.asname,
+                    SymbolKind.Variable,
+                    node.lineno,
+                    node.col_offset,
+                    container=container
+                )
 
     def visit_ClassDef(self, node, container):
         if self.kind == "class" and self.name == node.name:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git://github.com/sourcegraph/jedi.git@5ddbb290b458ff2e0d4da198d32c9a4f4e1e6733#egg=jedi
+-e git://github.com/sourcegraph/jedi.git@9a3e7256df2e6099207fd7289141885ec17ebec7#egg=jedi
 
 -e git://github.com/sourcegraph/pip#egg=pip
 


### PR DESCRIPTION
scan imports more thoroughly for x-definitions

use a newer fork of Jedi (allow ImplicitNamespaceContexts to use a RemoteFS)

make fs.listdir behave more like os.listdir (return filenames, not Entry objects)

make sure we actually have a symbol descriptor before trying to assign fields to it

If we're returning an implicit namespace package, then return an ImplicitNSInfo for the module path. Also pass our filesystem abstraction into the Script constructor so that the ImplicitNamespaceContext can eventually use it when looking up namespace package contents.

set a field on module objects indicating whether they're implicit namespace packages

show all assignments and definitions when looking for definitions, but filter out the current import or module