### PR TITLE
fix indexing std lib when using virtualenv

### DIFF
--- a/langserver/config.py
+++ b/langserver/config.py
@@ -1,12 +1,12 @@
 import os
 import os.path
-
+import distutils
 
 class GlobalConfig:
 
     # TODO: allow different Python stdlib versions per workspace?
 
-    PYTHON_PATH = os.path.dirname(os.__file__)
+    PYTHON_PATH = distutils.sysconfig.get_python_lib(standard_lib=True)
     PACKAGES_PARENT = "python-langserver-cache"
     STDLIB_REPO_URL = "git://github.com/python/cpython"
     STDLIB_SRC_PATH = "Lib"


### PR DESCRIPTION
When running the project using virtualenv, `GlobalConfig.PYTHON_PATH` refers to the the location of the virtual environment. The virtual environment doesn't have all the standard lib modules copied inside of it. Using `distutils` as described here fixes the issue: 

https://stackoverflow.com/questions/6463918/how-can-i-get-a-list-of-all-the-python-standard-library-modules

Note that https://stackoverflow.com/a/8992937 supposedly describes a better way to do this than the parent answer, but I haven't tested it yet. In any case, just using distutils isn't regressing from what we had before. 

