### PR TITLE
Fix not fetching external dependencies if they have conflicting moudle names

### DIFF
--- a/langserver/workspace.py
+++ b/langserver/workspace.py
@@ -163,7 +163,7 @@ class Workspace:
                                 is_stdlib)
             index[qualified_name] = the_module
             self.module_paths[os.path.abspath(the_module.path)] = the_module
-            self.fetched.add(module_name)
+    
         elif extension == ".py":
             # just a regular non-package module
             the_module = Module(basename,
@@ -174,7 +174,7 @@ class Workspace:
                                 is_stdlib)
             index[qualified_name] = the_module
             self.module_paths[os.path.abspath(the_module.path)] = the_module
-            self.fetched.add(basename)
+            
         elif extension == ".so":
             # native module -- mark it as such and report a warning or something
             the_module = Module(basename,
@@ -186,7 +186,7 @@ class Workspace:
                                 True)
             index[qualified_name] = the_module
             self.module_paths[os.path.abspath(the_module.path)] = the_module
-            self.fetched.add(basename)
+            
 
     def index_project(self):
         """

--- a/test/repos/confl_dep/Pipfile
+++ b/test/repos/confl_dep/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+
+[packages]
+
+django = "==2.0.2"
+"jinja2" = "==2.10"
+
+
+[dev-packages]
+

--- a/test/repos/confl_dep/Pipfile.lock
+++ b/test/repos/confl_dep/Pipfile.lock
@@ -1,0 +1,66 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "2a380096814cf288f4c3955aa5334416e74361b32507e9428102862da0ec15b9"
+        },
+        "host-environment-markers": {
+            "implementation_name": "cpython",
+            "implementation_version": "3.6.4",
+            "os_name": "posix",
+            "platform_machine": "x86_64",
+            "platform_python_implementation": "CPython",
+            "platform_release": "17.4.0",
+            "platform_system": "Darwin",
+            "platform_version": "Darwin Kernel Version 17.4.0: Sun Dec 17 09:19:54 PST 2017; root:xnu-4570.41.2~1/RELEASE_X86_64",
+            "python_full_version": "3.6.4",
+            "python_version": "3.6",
+            "sys_platform": "darwin"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "django": {
+            "hashes": [
+                "sha256:7c8ff92285406fb349e765e9ade685eec7271d6f5c3f918e495a74768b765c99",
+                "sha256:dc3b61d054f1bced64628c62025d480f655303aea9f408e5996c339a543b45f0"
+            ],
+            "version": "==2.0.2"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
+                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+            ],
+            "version": "==2.10"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+            ],
+            "version": "==1.0"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:ed6509d9af298b7995d69a440e2822288f2eca1681b8cce37673dbb10091e5fe",
+                "sha256:f93ddcdd6342f94cea379c73cddb5724e0d6d0a1c91c9bdef364dc0368ba4fda",
+                "sha256:61242a9abc626379574a166dc0e96a66cd7c3b27fc10868003fa210be4bff1c9",
+                "sha256:ba18e6a243b3625513d85239b3e49055a2f0318466e0b8a92b8fb8ca7ccdf55f",
+                "sha256:07edfc3d4d2705a20a6e99d97f0c4b61c800b8232dc1c04d87e8554f130148dd",
+                "sha256:3a47ff71597f821cd84a162e71593004286e5be07a340fd462f0d33a760782b5",
+                "sha256:5bd55c744e6feaa4d599a6cbd8228b4f8f9ba96de2c38d56f08e534b3c9edf0d",
+                "sha256:887ab5e5b32e4d0c86efddd3d055c1f363cbaa583beb8da5e22d2fa2f64d51ef",
+                "sha256:410bcd1d6409026fbaa65d9ed33bf6dd8b1e94a499e32168acfc7b332e4095c0"
+            ],
+            "version": "==2018.3"
+        }
+    },
+    "develop": {}
+}

--- a/test/repos/confl_dep/confl_dep/__main__.py
+++ b/test/repos/confl_dep/confl_dep/__main__.py
@@ -1,0 +1,2 @@
+import django
+import jinja2

--- a/test/test_conflictingdeps.py
+++ b/test/test_conflictingdeps.py
@@ -1,0 +1,66 @@
+from .harness import Harness
+import uuid
+import pytest
+
+@pytest.fixture()
+def workspace():
+    workspace = Harness("repos/confl_dep")
+    workspace.initialize("repos/confl_dep?" + str(uuid.uuid4()))
+    yield workspace
+    workspace.exit()
+
+class TestConflictingDependencies:
+    def test_hover_packages_conflicting_module_names(self, workspace):
+        uri = "file:///confl_dep/__main__.py"
+    
+        # django import
+        d_line, d_col = 0, 11
+        d_result = workspace.hover(uri, d_line, d_col)
+        assert d_result == {
+            'contents': [
+                {
+                    'language': 'python', 
+                    'value': 'django'
+                }
+            ]
+        }
+
+        # jinja2 import
+        j_line, j_col = 1, 11
+        j_result = workspace.hover(uri, j_line, j_col)
+        assert j_result == {
+            'contents': [
+                {
+                    'language': 'python', 
+                    'value': 'jinja2'
+                }, 
+                'jinja2\n'
+                '~~~~~~\n'
+                '\n'
+                'Jinja2 is a template engine written in pure Python.  It '
+                'provides a\n'
+                'Django inspired non-XML syntax but supports inline expressions '
+                'and\n'
+                'an optional sandboxed environment.\n'
+                '\n'
+                'Nutshell\n'
+                '--------\n'
+                '\n'
+                'Here a small example of a Jinja2 template::\n'
+                '\n'
+                "    {% extends 'base.html' %}\n"
+                '    {% block title %}Memberlist{% endblock %}\n'
+                '    {% block content %}\n'
+                '      <ul>\n'
+                '      {% for user in users %}\n'
+                '        <li><a href="{{ user.url }}">{{ user.username '
+                '}}</a></li>\n'
+                '      {% endfor %}\n'
+                '      </ul>\n'
+                '    {% endblock %}\n'
+                '\n'
+                '\n'
+                ':copyright: (c) 2017 by the Jinja Team.\n'
+                ':license: BSD, see LICENSE for more details.'
+            ]
+        }


### PR DESCRIPTION
See: https://github.com/sourcegraph/sourcegraph/issues/9745

Django and Jinja2 are in a similar situation to the above example in the issue. 

Django has a module named `jinja2`: https://sourcegraph.com/github.com/django/django/-/blob/django/template/backends/jinja2.py

Previously, if a project depends on `django` and `jinja2`, and `django` was indexed first, then all references to the `jinja2` package in the project would refer to the `jinja2` module in `django` instead of the pypi package. 

I think the fix is to stop adding all indexed modules to the `workspace.fetched` set, and only add to it whenever we actually fetch a package from pypi.

This PR makes the mentioned change, and adds a test case for this behavior. 
