### PR TITLE
fix module resolution when external pkg has module with same name

### DIFF
--- a/langserver/workspace.py
+++ b/langserver/workspace.py
@@ -357,7 +357,7 @@ class Workspace:
             elif self.folder_exists(os.path.join(parent, name)):
                 # there's a folder at this level that implements a namespace package with the name we're looking for
                 module_paths.append(os.path.join(parent, name))
-            elif os.path.basename(parent) == name:
+            elif self.folder_exists(parent) and os.path.basename(parent) == name:
                 # we're already in a namespace package with the name we're looking for
                 module_paths.append(parent)
         if not module_paths:

--- a/test/repos/dep_pkg_module_same_name/Pipfile
+++ b/test/repos/dep_pkg_module_same_name/Pipfile
@@ -1,0 +1,3 @@
+[packages]
+
+libfarhan = "==0.6"

--- a/test/repos/dep_pkg_module_same_name/Pipfile.lock
+++ b/test/repos/dep_pkg_module_same_name/Pipfile.lock
@@ -1,0 +1,38 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "17954e6b1f46d7b38e22fd1a3bcbb6ebdcaa6575bc0db837a2d510feab1107f4"
+        },
+        "host-environment-markers": {
+            "implementation_name": "cpython",
+            "implementation_version": "3.6.4",
+            "os_name": "posix",
+            "platform_machine": "x86_64",
+            "platform_python_implementation": "CPython",
+            "platform_release": "16.7.0",
+            "platform_system": "Darwin",
+            "platform_version": "Darwin Kernel Version 16.7.0: Thu Jun 15 17:36:27 PDT 2017; root:xnu-3789.70.16~2/RELEASE_X86_64",
+            "python_full_version": "3.6.4",
+            "python_version": "3.6",
+            "sys_platform": "darwin"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "libfarhan": {
+            "hashes": [
+                "sha256:9728b55dccfb5e7cf55867bf1a1f7e0db25297e6b05b72f49d8a4e7926354a2a"
+            ],
+            "version": "==0.6"
+        }
+    },
+    "develop": {}
+}

--- a/test/repos/dep_pkg_module_same_name/pyconfig.json
+++ b/test/repos/dep_pkg_module_same_name/pyconfig.json
@@ -1,0 +1,22 @@
+{
+    "packages": [
+      {
+        "package_name": "django",
+        "version": ">0.5.0",
+        "source" : {
+          "name": "pypi",
+          "verify_ssl": "True",
+          "url": "https://pypi.python.org/simple"
+        }
+      },
+      {
+        "package_name": "eventlet",
+        "version": ">=0.16.1,<0.19.0",
+        "source" : {
+          "name": "pypi",
+          "verify_ssl": "True",
+          "url": "https://pypi.python.org/simple"
+        }
+      }
+    ]
+}

--- a/test/repos/dep_pkg_module_same_name/test.py
+++ b/test/repos/dep_pkg_module_same_name/test.py
@@ -1,0 +1,3 @@
+from libfarhan import libfarhan.testfunc
+
+print(libfarhan.testfunc())

--- a/test/test_modpkgsamename.py
+++ b/test/test_modpkgsamename.py
@@ -1,0 +1,25 @@
+from .harness import Harness
+import uuid
+import pytest
+
+@pytest.fixture()
+def workspace():
+    workspace = Harness("repos/dep_pkg_module_same_name")
+    workspace.initialize("repos/dep_pkg_module_same_name" + str(uuid.uuid4()))
+    yield workspace
+    workspace.exit()
+
+class TestExtPkgHasModuleWithSameName:
+    def test_hover_pkg_module_same_name(self, workspace):
+        uri = "file:///test.py"
+        line, col = 2, 18
+        result = workspace.hover(uri, line, col)
+        assert result == {
+            'contents': [
+                {
+                    'language': 'python', 
+                    'value': 'def testfunc()'
+                }, 
+                'this is version 0.6'
+            ]
+        }


### PR DESCRIPTION
Example: 

We have a package named `libfarhan` that contains a module named `libfarhan`. 

```py
/libfarhan
/libfarhan/libfarhan.py
```

We have a project `test` that imports `libfarhan` in the following manner:
```py
from libfarhan import libfarhan.testfunc
 
print(libfarhan.testfunc())
```

If we hover over `testfunc()` in the print statement, we will get an error that looks like: 

```python
FileNotFoundError: [Errno 2] No such file or directory: '/Users/ggilmore/dev/python/python-langserver/test/repos/dep_pkg_module_same_name/Users/ggilmore/dev/python/python-langserver/test/python-langserver-cache/repos.dep_pkg_module_same_name30809c89-020e-4153-b5e1-d04804d707e6/libfarhan-0.6/libfarhan'
```

What's happening: 

When we run our own `find_module_remote` in (https://github.com/sourcegraph/python-langserver/blob/c46923de869fcb4f82ecb1078b9e5a5e839f3e0f/langserver/jedi.py#L62-L138), we: 

1. ~~Check if it's a `stdlib` module~~ (this never happens in this case)
2. Check if the requested module lives in the project already
3. Check to see if the module is a third party dependency. 

Jedi resolves the hover for `libfarhan.libfarhan.testfunc` in two steps: 

1. Resolve the outer `libfarhan` module. Jedi doesn't give us a list of `dirs` to look for the module in this case. 

   - > Check if the requested module lives in the project already
       - In this case, there is no folder or module inside the `test` project named `libfarhan`, so we don't find anything internally. 
   - > Check to see if the module is a third party dependency.
       - Given what happened earlier, we then fetch the `libfarhan` package from pypi and pass its info that back to jedi (i.e. the location of `libfarhan` is `[/python-langserver/test/python-langserver-cache/repos.dep_pkg_module_same_name30809c89-020e-4153-b5e1-d04804d707e6/libfarhan-0.6/libfarhan]`)

2. Resolve `libfarhan.libfarhan`. Jedi asks us to resolve the inner `libfarhan` in the context of the location for the outer `libfarhan` package that we passed it in step one (e.g. `dir = [/python-langserver/test/python-langserver-cache/repos.dep_pkg_module_same_name30809c89-020e-4153-b5e1-d04804d707e6/libfarhan-0.6/libfarhan]').`
    - > Check if the request module lives in the project already
       - When running find internal module, there is a conditional at the end of the chain (https://github.com/sourcegraph/python-langserver/blob/master/langserver/workspace.py#L360-L362) that **only** checks to see if one of the locations to look for the module `libfarhan` ends with the same name as the module. In this case, the location is `/python-langserver/test/python-langserver-cache/repos.dep_pkg_module_same_name30809c89-020e-4153-b5e1-d04804d707e6/libfarhan-0.6/libfarhan]`, and so the function returns a response that says that libfarhan exists inside the project (**even though it doesn't**). This is ultimiately the cause of the the `filenotfound` error above. 

The fix here is change that last conditional to **also** check to see if the given location exists in the project at all. This PR fixes that and adds a test case. 
