### PR TITLE
set env vars from initializationOptions

### DIFF
--- a/langserver/fetch.py
+++ b/langserver/fetch.py
@@ -7,10 +7,12 @@ import logging
 import pip
 import pip.status_codes
 
+from typing import List
+
 log = logging.getLogger(__name__)
 
-
-def fetch_dependency(module_name: str, specifier: str, install_path: str):
+# NEXT: pass in args here, instead of relying on environment vars
+def fetch_dependency(module_name: str, specifier: str, install_path: str, pip_args: List[str]):
     """Shells out to PIP in order to download and unzip the named package into
     the specified path. This method only runs `pip download`, NOT `pip
     install`, so it's presumably safe.
@@ -24,13 +26,7 @@ def fetch_dependency(module_name: str, specifier: str, install_path: str):
                  module_name, download_folder, exc_info=True)
         # TODO: check the result status
 
-        index_url = os.environ.get('INDEX_URL')
-        if index_url is not None:
-            result = pip.main(["download", "--no-deps", "-i", index_url,
-                               "-d", download_folder, module_name + specifier])
-        else:
-            result = pip.main(["download", "--no-deps", "-d",
-                               download_folder, module_name + specifier])
+        result = pip.main(["download", "--no-deps", "-d", download_folder] + pip_args + [module_name + specifier])
         if result != pip.status_codes.SUCCESS:
             log.error("Unable to fetch package %s", module_name)
             return

--- a/langserver/fetch.py
+++ b/langserver/fetch.py
@@ -11,7 +11,7 @@ from typing import List
 
 log = logging.getLogger(__name__)
 
-# NEXT: pass in args here, instead of relying on environment vars
+
 def fetch_dependency(module_name: str, specifier: str, install_path: str, pip_args: List[str]):
     """Shells out to PIP in order to download and unzip the named package into
     the specified path. This method only runs `pip download`, NOT `pip
@@ -26,7 +26,11 @@ def fetch_dependency(module_name: str, specifier: str, install_path: str, pip_ar
                  module_name, download_folder, exc_info=True)
         # TODO: check the result status
 
-        result = pip.main(["download", "--no-deps", "-d", download_folder] + pip_args + [module_name + specifier])
+        result = pip.main(
+            ["download", "--no-deps", "-d", download_folder] +
+            pip_args +
+            [module_name + specifier]
+        )
         if result != pip.status_codes.SUCCESS:
             log.error("Unable to fetch package %s", module_name)
             return

--- a/langserver/langserver.py
+++ b/langserver/langserver.py
@@ -151,8 +151,28 @@ class LangServer:
                                           "Script.usages"):
             return script.usages()
 
+    def setenv_from_initialization_options(self, params):
+        '''Sets environment variables from initializationOptions. This sets
+        environment variables for the entire process. In the future, this
+        might be modified to manage environment variables per workspace.'''
+
+        if "initializationOptions" not in params:
+            return
+        initOptions = params["initializationOptions"]
+        if not isinstance(initOptions, dict):
+            return
+        if "env" not in initOptions:
+            return
+        envVars = initOptions["env"]
+        if not isinstance(envVars, dict):
+            return
+        for k, v in envVars.items():
+            os.environ[k] = v
+
     def serve_initialize(self, request):
         params = request["params"]
+        self.setenv_from_initialization_options(params)
+
         self.root_path = path_from_uri(
             params.get("rootUri") or params.get("rootPath") or "")
 

--- a/langserver/langserver.py
+++ b/langserver/langserver.py
@@ -164,8 +164,14 @@ class LangServer:
             self.fs = LocalFileSystem()
 
         pip_args = []
-        if "initializationOptions" in params and "pipArgs" in params["initializationOptions"]:
-            pip_args = params["initializationOptions"]["pipArgs"]
+        if "initializationOptions" in params:
+            initOps = params["initializationOptions"]
+            if isinstance(initOps, dict) and "pipArgs" in initOps:
+                p = initOps["pipArgs"]
+                if isinstance(p, list):
+                    pip_args = p
+                else:
+                    log.error("pipArgs (%s) found, but was not a list, so ignoring", str(p))
 
         # Sourcegraph also passes in a rootUri which has commit information
         originalRootUri = params.get("originalRootUri") or params.get(

--- a/langserver/workspace.py
+++ b/langserver/workspace.py
@@ -55,8 +55,9 @@ class Module:
 class Workspace:
 
     def __init__(self, fs: FileSystem, project_root: str,
-                 original_root_path: str= ""):
+                 original_root_path: str= "", pip_args: List[str]=[]):
 
+        self.pip_args = pip_args
         self.project_packages = set()
         self.PROJECT_ROOT = project_root
         self.repo = None
@@ -300,7 +301,7 @@ class Workspace:
             self.indexing_lock.acquire()
             self.fetched.add(package_name)
             specifier = self.get_ext_pkg_version_specifier(package_name)
-            fetch_dependency(package_name, specifier, self.PACKAGES_PATH)
+            fetch_dependency(package_name, specifier, self.PACKAGES_PATH, self.pip_args)
             self.index_external_modules()
             self.indexing_lock.release()
         the_module = self.dependencies.get(qualified_name, None)


### PR DESCRIPTION
This sets environment variables via the `initializationOptions` field of the `initialize` request. This lets the client forward environment variables to configure pip to hit a custom index-url. For instance, one can send use the following `initialize` params:
```
{
  ...
  "initializationOptions": {
     "env": {
        "PIP_INDEX_URL": "http://pypi.sgdev.org/simple",
        "PIP_TRUSTEd_HOST": "pypi.sgdev.org"
      }
   }
}
```

Related change: https://github.com/sourcegraph/sourcegraph/pull/9969