### PR TITLE
Fix build

### DIFF
--- a/langserver/fetch.py
+++ b/langserver/fetch.py
@@ -5,7 +5,6 @@ import shutil
 import logging
 
 import pip
-import pip.status_codes
 
 from typing import List
 
@@ -31,7 +30,7 @@ def fetch_dependency(module_name: str, specifier: str, install_path: str, pip_ar
             pip_args +
             [module_name + specifier]
         )
-        if result != pip.status_codes.SUCCESS:
+        if result != 0:
             log.error("Unable to fetch package %s", module_name)
             return
         for thing in os.listdir(download_folder):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "python-langserver.py", line 8, in <module>
    from langserver.langserver import main  # noqa: E402
  File "/src/langserver/langserver.py", line 14, in <module>
    from .workspace import Workspace
  File "/src/langserver/workspace.py", line 4, in <module>
    from .fetch import fetch_dependency
  File "/src/langserver/fetch.py", line 8, in <module>
    import pip.status_codes
ModuleNotFoundError: No module named 'pip.status_codes'
```