### PR TITLE
add xworkspaceReferences capability

### DIFF
--- a/langserver/langserver.py
+++ b/langserver/langserver.py
@@ -187,6 +187,7 @@ class LangServer:
                 "workspaceSymbolProvider": True,
                 "streaming": True,
                 "xdefinitionProvider": True,
+                "xworkspaceReferencesProvider": True,
             }
         }
 


### PR DESCRIPTION
add xworkspaceReferencesProvider capability as defined in https://github.com/sourcegraph/language-server-protocol/blob/master/extension-workspace-references.md#workspacexreferences-extension-to-lsp