### PR TITLE
Return empty contents on no hover

### DIFF
--- a/langserver/langserver.py
+++ b/langserver/langserver.py
@@ -220,7 +220,7 @@ class LangServer:
         parent_span = request.get("span", None)
         source = self.fs.open(path, parent_span)
         if len(source.split("\n")[pos["line"]]) < pos["character"]:
-            return {}
+            return {"contents": []}
         script = self.new_script(
             path=path,
             source=source,
@@ -320,10 +320,7 @@ class LangServer:
                 elif definition.type == "statement":
                     results.append("variable `" + definition.name + "`")
 
-        if results:
-            return {"contents": results}
-        else:
-            return {}
+        return {"contents": results}
 
     def serve_definition(self, request):
         return list(

--- a/test_langserver.py
+++ b/test_langserver.py
@@ -84,7 +84,7 @@ def test_hover_on_def():
 
 def test_hover_on_string_literal():
     h = hover('/c.py', 5, 21)
-    assert h == {}  # expect no hover on a string literal
+    assert h == {"contents": []}  # expect no hover on a string literal
 
 
 def test_hover_on_string_variable():


### PR DESCRIPTION
The spec for hover response is `Hover | null`, where `Hover` has a required
field `contents`. Currently we returned `{}` which was missing `contents`.

Fixes https://github.com/sourcegraph/python-langserver/issues/55