### PR TITLE
use pip via subprocess, not pip.main

### DIFF
--- a/langserver/fetch.py
+++ b/langserver/fetch.py
@@ -4,8 +4,6 @@ import os
 import shutil
 import logging
 
-import pip
-
 from typing import List
 
 log = logging.getLogger(__name__)

--- a/langserver/fetch.py
+++ b/langserver/fetch.py
@@ -25,12 +25,12 @@ def fetch_dependency(module_name: str, specifier: str, install_path: str, pip_ar
                  module_name, download_folder, exc_info=True)
         # TODO: check the result status
 
-        result = pip.main(
-            ["download", "--no-deps", "-d", download_folder] +
+        result = subprocess.run(
+            ["pip", "download", "--no-deps", "-d", download_folder] +
             pip_args +
             [module_name + specifier]
         )
-        if result != 0:
+        if result.returncode != 0:
             log.error("Unable to fetch package %s", module_name)
             return
         for thing in os.listdir(download_folder):


### PR DESCRIPTION
`pip` [doesn't have a public api for a good reason](https://github.com/pypa/pip/issues/3121#issuecomment-170874168). It has broken at least three times over the past few months, and we gain nothing by using `pip` as a module versus just using it as a sub-process.